### PR TITLE
Added exportation support to cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,11 +4,11 @@
 
 cmake_minimum_required(VERSION 3.12)
 
-project(vmcontainer)
+project(vmcontainer CXX)
 
 enable_testing()
 
-# For CMAKE_INSTALL_INCLUDEDIR and CMAKE_INSTALL_DATADIR
+# For CMAKE_INSTALL_<LIBDIR, INLCUDEDIR, BINDIR, DATADIR>
 include(GNUInstallDirs)
 
 add_subdirectory(lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,25 +5,11 @@
 
 cmake_minimum_required(VERSION 3.12)
 
-# TODO: To replace by PROJECT_IS_TOP_LEVEL when requiring CMake 3.21
-if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
-  set(VMCONTAINER_STANDALONE ON)
-else()
-  set(VMCONTAINER_STANDALONE OFF)
-endif()
-
 project(vmcontainer CXX)
-
-option(VMCONTAINER_BUILD_TESTS "Enable the vmcontainer test suite" ${VMCONTAINER_STANDALONE})
-option(VMCONTAINER_BUILD_BENCHMARKS "Enable the vmcontainer benchmark suite" ${VMCONTAINER_STANDALONE})
 
 add_subdirectory(lib)
 
-if(VMCONTAINER_BUILD_BENCHMARKS)
-  add_subdirectory(benchmarks)
-endif()
+add_subdirectory(benchmarks)
 
-if(VMCONTAINER_BUILD_TESTS)
-  enable_testing()
-  add_subdirectory(tests)
-endif()
+enable_testing()
+add_subdirectory(tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,9 +7,9 @@ cmake_minimum_required(VERSION 3.12)
 
 # TODO: To replace by PROJECT_IS_TOP_LEVEL when requiring CMake 3.21
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
-    set(VMCONTAINER_STANDALONE ON)
+  set(VMCONTAINER_STANDALONE ON)
 else()
-    set(VMCONTAINER_STANDALONE OFF)
+  set(VMCONTAINER_STANDALONE OFF)
 endif()
 
 project(vmcontainer CXX)
@@ -20,10 +20,10 @@ option(VMCONTAINER_BUILD_BENCHMARKS "Enable the vmcontainer benchmark suite" ${V
 add_subdirectory(lib)
 
 if(VMCONTAINER_BUILD_BENCHMARKS)
-    add_subdirectory(benchmarks)
+  add_subdirectory(benchmarks)
 endif()
 
 if(VMCONTAINER_BUILD_TESTS)
-    enable_testing()
-    add_subdirectory(tests)
+  enable_testing()
+  add_subdirectory(tests)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,28 @@ project(vmcontainer)
 
 enable_testing()
 
+# For CMAKE_INSTALL_INCLUDEDIR and CMAKE_INSTALL_DATADIR
+include(GNUInstallDirs)
+
 add_subdirectory(lib)
 
 add_subdirectory(benchmarks)
 add_subdirectory(tests)
+
+install(TARGETS vmcontainer
+    EXPORT vmcontainer-config
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
+export(
+    TARGETS vmcontainer
+    NAMESPACE vmcontainer::
+    FILE "${PROJECT_BINARY_DIR}/vmcontainer-config.cmake"
+)
+
+install(EXPORT vmcontainer-config
+    DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/vmcontainer"
+    NAMESPACE vmcontainer::
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,35 +1,29 @@
-# This file is intended for use by library developers/maintainers.
-# It declares targets for unit tests and benchmarks.
-# If you only want to use the library consume lib/CMakeLists.txt instead.
+# This file is intended for use by library developers/maintainers, as well as users and package managers.
+# It declares targets for unit tests and benchmarks and exposes options.
+# This CMake project supports being embedded into other projects using add_subdirectory.
+# This CMake project also support being found by find_package(vmcontainer).
 
 cmake_minimum_required(VERSION 3.12)
 
+# TODO: To replace by PROJECT_IS_TOP_LEVEL when requiring CMake 3.21
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    set(VMCONTAINER_STANDALONE ON)
+else()
+    set(VMCONTAINER_STANDALONE OFF)
+endif()
+
 project(vmcontainer CXX)
 
-enable_testing()
-
-# For CMAKE_INSTALL_<LIBDIR, INLCUDEDIR, BINDIR, DATADIR>
-include(GNUInstallDirs)
+option(VMCONTAINER_BUILD_TESTS "Enable the vmcontainer test suite" ${VMCONTAINER_STANDALONE})
+option(VMCONTAINER_BUILD_BENCHMARKS "Enable the vmcontainer benchmark suite" ${VMCONTAINER_STANDALONE})
 
 add_subdirectory(lib)
 
-add_subdirectory(benchmarks)
-add_subdirectory(tests)
+if(VMCONTAINER_BUILD_BENCHMARKS)
+    add_subdirectory(benchmarks)
+endif()
 
-install(TARGETS vmcontainer
-    EXPORT vmcontainer-config
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-)
-
-export(
-    TARGETS vmcontainer
-    NAMESPACE vmcontainer::
-    FILE "${PROJECT_BINARY_DIR}/vmcontainer-config.cmake"
-)
-
-install(EXPORT vmcontainer-config
-    DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/vmcontainer"
-    NAMESPACE vmcontainer::
-)
+if(VMCONTAINER_BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(tests)
+endif()

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -11,7 +11,7 @@ add_library(vmcontainer.bench.dependencies INTERFACE)
 target_link_libraries(
   vmcontainer.bench.dependencies
   INTERFACE
-  vmcontainer
+  vmcontainer::vmcontainer
   benchmark::benchmark
   benchmark::benchmark_main
 )

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -2,6 +2,8 @@ file(GLOB_RECURSE vmcontainer-sources CONFIGURE_DEPENDS *.cpp)
 add_library(vmcontainer ${vmcontainer-sources})
 add_library(vmcontainer::vmcontainer ALIAS vmcontainer)
 
+# For CMAKE_INSTALL_<LIBDIR, INLCUDEDIR, BINDIR, DATADIR>
+include(GNUInstallDirs)
 
 target_include_directories(vmcontainer PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -14,4 +16,22 @@ set_target_properties(vmcontainer PROPERTIES DEBUG_POSTFIX -d)
 install(
     DIRECTORY include/vmcontainer
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} FILES_MATCHING PATTERN "*.hpp"
+)
+
+install(TARGETS vmcontainer
+    EXPORT vmcontainer-config
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
+export(
+    TARGETS vmcontainer
+    NAMESPACE vmcontainer::
+    FILE "${PROJECT_BINARY_DIR}/vmcontainer-config.cmake"
+)
+
+install(EXPORT vmcontainer-config
+    DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/vmcontainer"
+    NAMESPACE vmcontainer::
 )

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,3 +1,7 @@
+cmake_minimum_required(VERSION 3.12)
+
+project(vmcontainer CXX)
+
 file(GLOB_RECURSE vmcontainer-sources CONFIGURE_DEPENDS *.cpp)
 add_library(vmcontainer ${vmcontainer-sources})
 add_library(vmcontainer::vmcontainer ALIAS vmcontainer)
@@ -25,10 +29,11 @@ install(TARGETS vmcontainer
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 
+# Since there is two projects, we need to export into the parent directory
 export(
   TARGETS vmcontainer
   NAMESPACE vmcontainer::
-  FILE "${PROJECT_BINARY_DIR}/vmcontainer-config.cmake"
+  FILE "${PROJECT_BINARY_DIR}/../vmcontainer-config.cmake"
 )
 
 install(EXPORT vmcontainer-config

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -6,32 +6,32 @@ add_library(vmcontainer::vmcontainer ALIAS vmcontainer)
 include(GNUInstallDirs)
 
 target_include_directories(vmcontainer PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
 target_compile_features(vmcontainer PUBLIC cxx_std_14)
 set_target_properties(vmcontainer PROPERTIES DEBUG_POSTFIX -d)
 
 install(
-    DIRECTORY include/vmcontainer
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} FILES_MATCHING PATTERN "*.hpp"
+  DIRECTORY include/vmcontainer
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} FILES_MATCHING PATTERN "*.hpp"
 )
 
 install(TARGETS vmcontainer
-    EXPORT vmcontainer-config
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  EXPORT vmcontainer-config
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 
 export(
-    TARGETS vmcontainer
-    NAMESPACE vmcontainer::
-    FILE "${PROJECT_BINARY_DIR}/vmcontainer-config.cmake"
+  TARGETS vmcontainer
+  NAMESPACE vmcontainer::
+  FILE "${PROJECT_BINARY_DIR}/vmcontainer-config.cmake"
 )
 
 install(EXPORT vmcontainer-config
-    DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/vmcontainer"
-    NAMESPACE vmcontainer::
+  DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/vmcontainer"
+  NAMESPACE vmcontainer::
 )

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,10 +1,17 @@
-cmake_minimum_required(VERSION 3.12)
-
-project(vmcontainer)
-
 file(GLOB_RECURSE vmcontainer-sources CONFIGURE_DEPENDS *.cpp)
 add_library(vmcontainer ${vmcontainer-sources})
-add_library(mknejp::vmcontainer ALIAS vmcontainer)
+add_library(vmcontainer::vmcontainer ALIAS vmcontainer)
 
-target_include_directories(vmcontainer PUBLIC include)
+
+target_include_directories(vmcontainer PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
 target_compile_features(vmcontainer PUBLIC cxx_std_14)
+set_target_properties(vmcontainer PROPERTIES DEBUG_POSTFIX -d)
+
+install(
+    DIRECTORY include/vmcontainer
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} FILES_MATCHING PATTERN "*.hpp"
+)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,7 +3,7 @@ find_package(Catch2 CONFIG REQUIRED)
 file(GLOB_RECURSE vmcontainer.test-sources CONFIGURE_DEPENDS *.cpp)
 add_executable(vmcontainer.test ${vmcontainer.test-sources})
 
-target_link_libraries(vmcontainer.test PRIVATE vmcontainer Catch2::Catch2)
+target_link_libraries(vmcontainer.test PRIVATE vmcontainer::vmcontainer Catch2::Catch2)
 target_include_directories(vmcontainer.test PRIVATE .)
 
 add_test(NAME vmcontainer.test COMMAND vmcontainer.test)


### PR DESCRIPTION
This pull request only changes the CMake configuration.

> NOTE: I changed the alias target to be `vmcontainer::vmcontainer`. This is because the current convension using CMake is that a target named `package-name::package-name` exist after doing `find_package(package-name)`. This makes usage simpler and more in line with all other CMake packages.

This patch enable user to find the `vmcontainer` package using `find_package(vmcontainer)`. Version selection support is not enabled since there is no version yet.

The package can be found in two ways: 

 1. User set the prefix path to the build directory to directly use the header in the project tree.
 2. User install the library somewhere and set the prefix path to that somewhere instead

This patch was tested with `Ninja` generator and `Ninja Multi-Config` too. A debug and a release configuration can be installed side by side, at the same time, and user projects will select the right one depending on their build type.

This patch would make it possible to package the library in a package manager and let user find and use the package using native CMake functions.

Another change: I also removed the duplicated `project` calls, since it made making this patch easier.