### PR TITLE
Add options to disable benchmarks and tests, support FetchContent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,25 +6,24 @@
 
 cmake_minimum_required(VERSION 3.12)
 
-# TODO: To replace by PROJECT_IS_TOP_LEVEL when requiring CMake 3.21
-if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
-    set(VMCONTAINER_TOPLEVEL ON)
+if(VMCONTAINER_DEV_MODE)
+  set(VMCONTAINER_DEV_OPTION ON)
 else()
-    set(VMCONTAINER_TOPLEVEL OFF)
+  set(VMCONTAINER_DEV_OPTION OFF)
 endif()
 
 project(vmcontainer CXX)
 
-option(VMCONTAINER_BUILD_TESTS "Enable the vmcontainer test suite" ${VMCONTAINER_TOPLEVEL})
-option(VMCONTAINER_BUILD_BENCHMARKS "Enable the vmcontainer benchmark suite" ${VMCONTAINER_TOPLEVEL})
+option(VMCONTAINER_BUILD_TESTS "Enable the vmcontainer test suite" ${VMCONTAINER_DEV_OPTION})
+option(VMCONTAINER_BUILD_BENCHMARKS "Enable the vmcontainer benchmark suite" ${VMCONTAINER_DEV_OPTION})
 
 add_subdirectory(lib)
 
 if(VMCONTAINER_BUILD_BENCHMARKS)
-    add_subdirectory(benchmarks)
+  add_subdirectory(benchmarks)
 endif()
 
 if(VMCONTAINER_BUILD_TESTS)
-    enable_testing()
-    add_subdirectory(tests)
+  enable_testing()
+  add_subdirectory(tests)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,16 +6,11 @@
 
 cmake_minimum_required(VERSION 3.12)
 
-if(VMCONTAINER_DEV_MODE)
-  set(VMCONTAINER_DEV_OPTION ON)
-else()
-  set(VMCONTAINER_DEV_OPTION OFF)
-endif()
-
 project(vmcontainer CXX)
 
-option(VMCONTAINER_BUILD_TESTS "Enable the vmcontainer test suite" ${VMCONTAINER_DEV_OPTION})
-option(VMCONTAINER_BUILD_BENCHMARKS "Enable the vmcontainer benchmark suite" ${VMCONTAINER_DEV_OPTION})
+option(VMCONTAINER_DEV_MODE "Enables all the dev option by default")
+option(VMCONTAINER_BUILD_TESTS "Enable the vmcontainer test suite" ${VMCONTAINER_DEV_MODE})
+option(VMCONTAINER_BUILD_BENCHMARKS "Enable the vmcontainer benchmark suite" ${VMCONTAINER_DEV_MODE})
 
 add_subdirectory(lib)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,30 @@
-# This file is intended for use by library developers/maintainers.
-# It declares targets for unit tests and benchmarks.
-# If you only want to use the library consume lib/CMakeLists.txt instead.
+# This file is intended for use by library developers/maintainers, as well as users and package managers.
+# It declares targets for unit tests and benchmarks and exposes options.
+# This CMake project supports being embedded into other projects using add_subdirectory.
+# This CMake project also support being found by find_package(vmcontainer).
+# Also supports being used with FetchContent
 
 cmake_minimum_required(VERSION 3.12)
 
-project(vmcontainer)
+# TODO: To replace by PROJECT_IS_TOP_LEVEL when requiring CMake 3.21
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    set(VMCONTAINER_TOPLEVEL ON)
+else()
+    set(VMCONTAINER_TOPLEVEL OFF)
+endif()
 
-enable_testing()
+project(vmcontainer CXX)
+
+option(VMCONTAINER_BUILD_TESTS "Enable the vmcontainer test suite" ${VMCONTAINER_TOPLEVEL})
+option(VMCONTAINER_BUILD_BENCHMARKS "Enable the vmcontainer benchmark suite" ${VMCONTAINER_TOPLEVEL})
 
 add_subdirectory(lib)
 
-add_subdirectory(benchmarks)
-add_subdirectory(tests)
+if(VMCONTAINER_BUILD_BENCHMARKS)
+    add_subdirectory(benchmarks)
+endif()
+
+if(VMCONTAINER_BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(tests)
+endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -15,7 +15,8 @@
           "value": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
           "type": "FILEPATH"
         },
-        "CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/${presetName}"
+        "CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/${presetName}",
+        "VMCONTAINER_DEV_MODE": true
       }
     },
     {
@@ -62,6 +63,15 @@
       }
     },
     {
+      "name": "linux-base",
+      "inherits": "base",
+      "hidden": true,
+      "generator": "Ninja",
+      "cacheVariables": {
+        "VCPKG_TARGET_TRIPLET": "x64-linux"
+      }
+    },
+    {
       "name": "x64-windows-cl-std14-debug",
       "inherits": [ "windows-base", "debug", "std14" ],
       "displayName": "Windows x64 MSVC C++14 Debug",
@@ -76,6 +86,11 @@
       "cacheVariables": {
         "CMAKE_CXX_COMPILER": "cl"
       }
+    },
+    {
+      "name": "linux-debug",
+      "inherits": [ "linux-base", "debug", "std14" ],
+      "displayName": "Linux x64 C++14 Debug"
     }
   ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -63,15 +63,6 @@
       }
     },
     {
-      "name": "linux-base",
-      "inherits": "base",
-      "hidden": true,
-      "generator": "Ninja",
-      "cacheVariables": {
-        "VCPKG_TARGET_TRIPLET": "x64-linux"
-      }
-    },
-    {
       "name": "x64-windows-cl-std14-debug",
       "inherits": [ "windows-base", "debug", "std14" ],
       "displayName": "Windows x64 MSVC C++14 Debug",
@@ -86,11 +77,6 @@
       "cacheVariables": {
         "CMAKE_CXX_COMPILER": "cl"
       }
-    },
-    {
-      "name": "linux-debug",
-      "inherits": [ "linux-base", "debug", "std14" ],
-      "displayName": "Linux x64 C++14 Debug"
     }
   ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -16,7 +16,7 @@
           "type": "FILEPATH"
         },
         "CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/${presetName}",
-        "VMCONTAINER_DEV_MODE": true
+        "VMCONTAINER_DEV_MODE": "ON"
       }
     },
     {


### PR DESCRIPTION
This patch add support to disable tests or benchmarks when developing the library.

It adds options to the CMake GUI and command line interface. A feature useful by package maintainers and useful for CI, as you can build only the tests and not the benchmarks.

It also add support for `FetchContent` users. The toplevel `CMakeLists.txt` used by `FetchContent` will no longer build benchmarks by default if part of a parent project, and won't try to find external libraries, which users may not have available on their system.

It also add support for `add_subdirectory(vmcontainer)` as other CMake libraries support and just as most users would expect without reading the documentation (although there's a limit on how we can protect the user against not knowing how to use the lib).

I am not strongly opinionated on this, we could also simply provide a documentation that explains how to include the `lib/CMakeLists.txt` file using fetch content functions.

Originally part of #5 