### PR TITLE
Guard against WinAPI macro redefinition

### DIFF
--- a/lib/src/vmcontainer/vm.cpp
+++ b/lib/src/vmcontainer/vm.cpp
@@ -7,8 +7,12 @@
 #include "vmcontainer/vm.hpp"
 
 #ifdef WIN32
-#  define NOMINMAX
-#  define WIN32_LEAN_AND_MEAN
+#  ifndef NOMINMAX
+#    define NOMINMAX
+#  endif
+#  ifndef WIN32_LEAN_AND_MEAN
+#    define WIN32_LEAN_AND_MEAN
+#  endif
 #  include <windows.h>
 #else
 #  include <sys/mman.h>


### PR DESCRIPTION
First of all, thank you for finally publishing the code. It was very helpful in a project of mine.

When integrating your library into said project, there were compiler warnings due to macro redefinitions, because the project already defined the WinAPI macros globally. In order to prevent these added these prechecks.